### PR TITLE
Making Page Objects iterable.

### DIFF
--- a/coinbaseadvanced/models/accounts.py
+++ b/coinbaseadvanced/models/accounts.py
@@ -110,3 +110,6 @@ class AccountsPage:
 
         result = json.loads(response.text)
         return cls(**result)
+
+    def __iter__(self):
+        return self.accounts.__iter__()

--- a/coinbaseadvanced/models/orders.py
+++ b/coinbaseadvanced/models/orders.py
@@ -369,6 +369,9 @@ class OrdersPage:
         result = json.loads(response.text)
         return cls(**result)
 
+    def __iter__(self):
+        return self.orders.__iter__()
+
 
 class OrderCancellation:
     """
@@ -493,3 +496,6 @@ class FillsPage:
 
         result = json.loads(response.text)
         return cls(**result)
+
+    def __iter__(self):
+        return self.fills.__iter__()

--- a/coinbaseadvanced/models/products.py
+++ b/coinbaseadvanced/models/products.py
@@ -20,6 +20,7 @@ class ProductType(Enum):
 
     SPOT = "SPOT"
 
+
 GRANULARITY_MAP_IN_MINUTES = {
     "ONE_MINUTE": 1,
     "FIVE_MINUTE": 5,
@@ -30,6 +31,7 @@ GRANULARITY_MAP_IN_MINUTES = {
     "SIX_HOUR": 360,
     "ONE_DAY": 1440,
 }
+
 
 class Granularity(Enum):
     """
@@ -189,6 +191,9 @@ class ProductsPage:
         result = json.loads(response.text)
         return cls(**result)
 
+    def __iter__(self):
+        return self.products.__iter__()
+
 
 class Candle:
     """
@@ -232,6 +237,9 @@ class CandlesPage:
 
         result = json.loads(response.text)
         return cls(**result)
+
+    def __iter__(self):
+        return self.candles.__iter__()
 
 
 class Trade:
@@ -296,3 +304,6 @@ class TradesPage:
 
         result = json.loads(response.text)
         return cls(**result)
+
+    def __iter__(self):
+        return self.trades.__iter__()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -940,8 +940,6 @@ class TestCoinbaseAdvancedTradeAPIClient(unittest.TestCase):
 
         self.assertIsNotNone(trades_page)
 
-        trades = trades_page.trades
-
         for trade in trades_page:
             self.assertIsNotNone(trade)
             self.assertIsNotNone(trade.product_id)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -146,7 +146,7 @@ class TestCoinbaseAdvancedTradeAPIClient(unittest.TestCase):
         self.assertEqual(page.has_next, True)
         self.assertIsNotNone(page.cursor)
 
-        for account in accounts:
+        for account in page:
             self.assertIsNotNone(account)
             self.assertIsNotNone(account.uuid)
             self.assertIsNotNone(account.name)
@@ -531,7 +531,7 @@ class TestCoinbaseAdvancedTradeAPIClient(unittest.TestCase):
         orders = orders_page.orders
         self.assertEqual(len(orders), 10)
 
-        for order in orders:
+        for order in orders_page:
             self.assertIsNotNone(order)
             self.assertIsNotNone(order.order_id)
             self.assertIsNotNone(order.product_id)
@@ -660,7 +660,7 @@ class TestCoinbaseAdvancedTradeAPIClient(unittest.TestCase):
         fills = fills_page.fills
         self.assertEqual(len(fills), 5)
 
-        for fill in fills:
+        for fill in fills_page:
             self.assertIsNotNone(fill)
             self.assertIsNotNone(fill.order_id)
             self.assertIsNotNone(fill.product_id)
@@ -777,7 +777,7 @@ class TestCoinbaseAdvancedTradeAPIClient(unittest.TestCase):
         products = products_page.products
         self.assertEqual(len(products), 5)
 
-        for product in products:
+        for product in products_page:
             self.assertIsNotNone(product)
             self.assertIsNotNone(product.price)
             self.assertIsNotNone(product.product_id)
@@ -862,7 +862,7 @@ class TestCoinbaseAdvancedTradeAPIClient(unittest.TestCase):
         candles = product_candles.candles
         self.assertEqual(len(candles), 30)
 
-        for candle in candles:
+        for candle in product_candles:
             self.assertIsNotNone(candle)
             self.assertIsNotNone(candle.start)
             self.assertIsNotNone(candle.high)
@@ -942,7 +942,7 @@ class TestCoinbaseAdvancedTradeAPIClient(unittest.TestCase):
 
         trades = trades_page.trades
 
-        for trade in trades:
+        for trade in trades_page:
             self.assertIsNotNone(trade)
             self.assertIsNotNone(trade.product_id)
             self.assertIsNotNone(trade.price)


### PR DESCRIPTION
With this change, you can now iterate a page without explicitly call out for the page collection/container. 

**Before**
```
client = CoinbaseAdvancedTradeAPIClient(api_key='kjsldfk32234', secret_key='jlsjljsfd89y98y98shdfjksfd')
trades_page = client.get_market_trades("BTC-USD", limit=100)

trades = trades_page.trades

for trade in trades:
    ...
```

**After**
```
client = CoinbaseAdvancedTradeAPIClient(api_key='kjsldfk32234', secret_key='jlsjljsfd89y98y98shdfjksfd')
trades_page = client.get_market_trades("BTC-USD", limit=100)

for trade in trades_page:
    ...