### PR TITLE
Follow Up: Supporting Edit Order endpoint

### DIFF
--- a/coinbaseadvanced/client.py
+++ b/coinbaseadvanced/client.py
@@ -161,7 +161,8 @@ class CoinbaseAdvancedTradeAPIClient(object):
     def create_buy_market_order(self,
                                 client_order_id: str,
                                 product_id: str,
-                                quote_size: float) -> Order:
+                                quote_size: float,
+                                retail_portfolio_id: Optional[str] = None) -> Order:
         """
         https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_postorder
 
@@ -179,12 +180,13 @@ class CoinbaseAdvancedTradeAPIClient(object):
             }
         }
 
-        return self.create_order(client_order_id, product_id, Side.BUY, order_configuration)
+        return self.create_order(client_order_id, product_id, Side.BUY, order_configuration, retail_portfolio_id)
 
     def create_sell_market_order(self,
                                  client_order_id: str,
                                  product_id: str,
-                                 base_size: float) -> Order:
+                                 base_size: float,
+                                 retail_portfolio_id: Optional[str] = None) -> Order:
         """
         https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_postorder
 
@@ -202,7 +204,7 @@ class CoinbaseAdvancedTradeAPIClient(object):
             }
         }
 
-        return self.create_order(client_order_id, product_id, Side.SELL, order_configuration)
+        return self.create_order(client_order_id, product_id, Side.SELL, order_configuration, retail_portfolio_id)
 
     def create_limit_order(
             self,
@@ -212,7 +214,8 @@ class CoinbaseAdvancedTradeAPIClient(object):
             limit_price: float,
             base_size: float,
             cancel_time: Optional[datetime] = None,
-            post_only: Optional[bool] = None) -> Order:
+            post_only: Optional[bool] = None,
+            retail_portfolio_id: Optional[str] = None) -> Order:
         """
         https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_postorder
 
@@ -245,7 +248,7 @@ class CoinbaseAdvancedTradeAPIClient(object):
         else:
             order_configuration['limit_limit_gtc'] = limit_order_configuration
 
-        return self.create_order(client_order_id, product_id, side, order_configuration)
+        return self.create_order(client_order_id, product_id, side, order_configuration, retail_portfolio_id)
 
     def create_stop_limit_order(
             self,
@@ -256,7 +259,8 @@ class CoinbaseAdvancedTradeAPIClient(object):
             stop_direction: StopDirection,
             limit_price: float,
             base_size: float,
-            cancel_time: Optional[datetime] = None) -> Order:
+            cancel_time: Optional[datetime] = None,
+            retail_portfolio_id: Optional[str] = None) -> Order:
         """
         https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_postorder
 
@@ -294,12 +298,13 @@ class CoinbaseAdvancedTradeAPIClient(object):
         else:
             order_configuration['stop_limit_stop_limit_gtc'] = stop_limit_order_configuration
 
-        return self.create_order(client_order_id, product_id, side, order_configuration)
+        return self.create_order(client_order_id, product_id, side, order_configuration, retail_portfolio_id)
 
     def create_order(self, client_order_id: str,
                      product_id: str,
                      side: Side,
-                     order_configuration: dict) -> Order:
+                     order_configuration: dict,
+                     retail_portfolio_id: Optional[str] = None) -> Order:
         """
         https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_postorder
 
@@ -318,8 +323,10 @@ class CoinbaseAdvancedTradeAPIClient(object):
             'client_order_id': client_order_id,
             'product_id': product_id,
             'side': side.value,
-            'order_configuration': order_configuration
+            'order_configuration': order_configuration,
         }
+        if retail_portfolio_id is not None:
+            payload['retail_portfolio_id'] = retail_portfolio_id
 
         headers = self._build_request_headers(method, request_path, json.dumps(payload)) \
             if self._is_legacy_auth() \
@@ -359,7 +366,7 @@ class CoinbaseAdvancedTradeAPIClient(object):
                                  json=payload, headers=headers,
                                  timeout=self.timeout)
 
-        edit_result = OrderEdit.from_get_edit_response(response)
+        edit_result = OrderEdit.from_response(response)
         return edit_result
 
     def cancel_orders(self, order_ids: list) -> OrderBatchCancellation:

--- a/coinbaseadvanced/client.py
+++ b/coinbaseadvanced/client.py
@@ -21,7 +21,7 @@ from coinbaseadvanced.models.portfolios import Portfolio, PortfolioBreakdown, \
 from coinbaseadvanced.models.products import BidAsksPage, ProductBook, ProductsPage, Product, \
     CandlesPage, TradesPage, ProductType, Granularity, GRANULARITY_MAP_IN_MINUTES
 from coinbaseadvanced.models.accounts import AccountsPage, Account
-from coinbaseadvanced.models.orders import OrderPlacementSource, OrdersPage, Order, OrderEdit, \
+from coinbaseadvanced.models.orders import OrderEditPreview, OrderPlacementSource, OrdersPage, Order, OrderEdit, \
     OrderBatchCancellation, FillsPage, Side, StopDirection, OrderType
 
 
@@ -350,7 +350,7 @@ class CoinbaseAdvancedTradeAPIClient(object):
         - base_size: New size for order
         """
 
-        request_path = f"/api/v3/brokerage/orders/edit"
+        request_path = "/api/v3/brokerage/orders/edit"
         method = "POST"
 
         payload = {
@@ -367,6 +367,38 @@ class CoinbaseAdvancedTradeAPIClient(object):
                                  timeout=self.timeout)
 
         edit_result = OrderEdit.from_response(response)
+        return edit_result
+
+    def edit_order_preview(self, order_id: str, limit_price: float, base_size: float) -> OrderEditPreview:
+        """
+        https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_previeweditorder
+
+        Simulate an edit order request with a specified new size, or new price, to preview the result of an edit.
+        Only limit order types, with time in force type of good-till-cancelled can be edited.
+
+        Args:
+        - order_id: ID of order to edit.
+        - limit_price: New price for order.
+        - base_size: New size for order
+        """
+
+        request_path = "/api/v3/brokerage/orders/edit_preview"
+        method = "POST"
+
+        payload = {
+            'order_id': order_id,
+            'price': str(limit_price),
+            'size': str(base_size)
+        }
+
+        headers = self._build_request_headers(method, request_path, json.dumps(payload)) \
+            if self._is_legacy_auth() \
+            else self._build_request_headers_for_cloud(method, self._host, request_path)
+        response = requests.post(self._base_url+request_path,
+                                 json=payload, headers=headers,
+                                 timeout=self.timeout)
+
+        edit_result = OrderEditPreview.from_response(response)
         return edit_result
 
     def cancel_orders(self, order_ids: list) -> OrderBatchCancellation:

--- a/coinbaseadvanced/models/orders.py
+++ b/coinbaseadvanced/models/orders.py
@@ -475,6 +475,47 @@ class OrderEdit(BaseModel):
         return cls(**result)
 
 
+class OrderEditPreview(BaseModel):
+    """
+    Order edit.
+    """
+
+    errors: Optional[List[dict]]
+    slippage: str
+    order_total: str
+    commission_total: str
+    quote_size: str
+    base_size: str
+    best_bid: str
+    best_ask: str
+    average_filled_price: str
+
+    def __init__(self, errors: Optional[List[dict]] = None, slippage: str = "", order_total: str = "", commission_total: str = "", quote_size: str = "", base_size: str = "", best_bid: str = "", best_ask: str = "", average_filled_price: str = "", **kwargs) -> None:
+        self.errors = errors
+        self.slippage = slippage
+        self.order_total = order_total
+        self.commission_total = commission_total
+        self.quote_size = quote_size
+        self.base_size = base_size
+        self.best_bid = best_bid
+        self.best_ask = best_ask
+        self.average_filled_price = average_filled_price
+
+        self.kwargs = kwargs
+
+    @classmethod
+    def from_response(cls, response: requests.Response) -> 'OrderEditPreview':
+        """
+        Factory Method.
+        """
+
+        if not response.ok:
+            raise CoinbaseAdvancedTradeAPIError.not_ok_response(response)
+
+        result = response.json()
+        return cls(**result)
+
+
 class OrderCancellation(BaseModel):
     """
     Order cancellation.

--- a/coinbaseadvanced/models/orders.py
+++ b/coinbaseadvanced/models/orders.py
@@ -450,18 +450,20 @@ class OrderEdit(BaseModel):
     """
 
     success: bool
-    errors: List[dict]
-    edit_failure_reason: str
-    preview_failure_reason: str
+    errors: Optional[List[dict]]
+    edit_failure_reason: Optional[str]
+    preview_failure_reason: Optional[str]
 
-    def __init__(self, success: bool, errors: List[dict], **kwargs) -> None:
+    def __init__(self, success: bool, errors: Optional[List[dict]] = None,  edit_failure_reason: Optional[str] = None, preview_failure_reason: Optional[str] = None,  **kwargs) -> None:
         self.success = success
-        self.errors = errors if errors is not None else None
+        self.errors = errors
+        self.edit_failure_reason = edit_failure_reason
+        self.preview_failure_reason = preview_failure_reason
 
         self.kwargs = kwargs
-    
+
     @classmethod
-    def from_get_edit_response(cls, response: requests.Response) -> 'OrderEdit':
+    def from_response(cls, response: requests.Response) -> 'OrderEdit':
         """
         Factory Method.
         """

--- a/tests/fixtures/edit_order_preview_success_response.json
+++ b/tests/fixtures/edit_order_preview_success_response.json
@@ -1,0 +1,11 @@
+{
+    "errors": [],
+    "slippage": "string",
+    "order_total": "string",
+    "commission_total": "string",
+    "quote_size": "string",
+    "base_size": "string",
+    "best_bid": "string",
+    "best_ask": "string",
+    "average_filled_price": "string"
+}

--- a/tests/fixtures/edit_order_success_response.json
+++ b/tests/fixtures/edit_order_success_response.json
@@ -1,0 +1,7 @@
+{
+    "success": true,
+    "errors": {
+        "edit_failure_reason": "UNKNOWN_EDIT_ORDER_FAILURE_REASON",
+        "preview_failure_reason": "UNKNOWN_PREVIEW_FAILURE_REASON"
+    }
+}

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -93,6 +93,14 @@ def fixture_create_sell_market_order_success_response() -> mock.Mock:
             text=content)
 
 
+def fixture_edit_order_success_response() -> mock.Mock:
+    with open('tests/fixtures/edit_order_success_response.json', 'r', encoding="utf-8") as file:
+        content = file.read()
+        return _fixtured_mock_response(
+            ok=True,
+            text=content)
+
+
 def fixture_default_order_failure_response() -> mock.Mock:
     with open('tests/fixtures/default_order_failure_response.json', 'r', encoding="utf-8") as file:
         content = file.read()

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -101,6 +101,14 @@ def fixture_edit_order_success_response() -> mock.Mock:
             text=content)
 
 
+def fixture_edit_order_preview_success_response() -> mock.Mock:
+    with open('tests/fixtures/edit_order_preview_success_response.json', 'r', encoding="utf-8") as file:
+        content = file.read()
+        return _fixtured_mock_response(
+            ok=True,
+            text=content)
+
+
 def fixture_default_order_failure_response() -> mock.Mock:
     with open('tests/fixtures/default_order_failure_response.json', 'r', encoding="utf-8") as file:
         content = file.read()

--- a/tests/playground.py
+++ b/tests/playground.py
@@ -77,11 +77,19 @@ print()
 #     'client_order_id': generate_random_id(),
 #     'product_id': "ALGO-USD",
 #     'side': Side.BUY,
-#     'limit_price': ".15",
-#     'base_size': 1000
+#     'limit_price': ".12",
+#     'base_size': 10,
+#     'retail_portfolio_id': "bba559eb-5b24-45f5-9898-472a81c46a56"
 # },
 #     fixture_obj
 # )
+
+# audit(client.edit_order, {
+#     'order_id': "754eb3d3-13ad-4f25-b239-c79257b49f10",
+#     'limit_price': 0.08,
+#     'base_size': 6
+# }, json.loads(
+#     fixture_edit_order_success_response().text))
 
 # audit(client.cancel_orders, {'order_ids': ["42a266d3-591b-43d4-a968-a9a126f7b1a5", "82c6919f-6884-4127-95af-11db89b21ed3",
 #       "c1d5ab66-d99a-4329-9c1d-be6a9f32c686"]}, json.loads(fixture_cancel_orders_success_response().text))

--- a/tests/playground.py
+++ b/tests/playground.py
@@ -91,6 +91,13 @@ print()
 # }, json.loads(
 #     fixture_edit_order_success_response().text))
 
+audit(client.edit_order_preview, {
+    'order_id': "754eb3d3-13ad-4f25-b239-c79257b49f10",
+    'limit_price': 0.08,
+    'base_size': 6
+}, json.loads(
+    fixture_edit_order_preview_success_response().text))
+
 # audit(client.cancel_orders, {'order_ids': ["42a266d3-591b-43d4-a968-a9a126f7b1a5", "82c6919f-6884-4127-95af-11db89b21ed3",
 #       "c1d5ab66-d99a-4329-9c1d-be6a9f32c686"]}, json.loads(fixture_cancel_orders_success_response().text))
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -471,6 +471,20 @@ class TestCoinbaseAdvancedTradeAPIClient(unittest.TestCase):
         self.assertIsNotNone(order.order_error)
 
     @mock.patch("coinbaseadvanced.client.requests.post")
+    def test_edit_order_success(self, mock_post):
+
+        mock_resp = fixture_edit_order_success_response()
+        mock_post.return_value = mock_resp
+
+        client = CoinbaseAdvancedTradeAPIClient(
+            api_key='kjsldfk32234', secret_key='jlsjljsfd89y98y98shdfjksfd')
+
+        # Check output
+        order_edited = client.edit_order("nlksdbnfgjd8y9mn,m234", .19, 10000)
+
+        self.assertTrue(order_edited.success)
+
+    @mock.patch("coinbaseadvanced.client.requests.post")
     def test_cancel_orders_success(self, mock_post):
 
         mock_resp = fixture_cancel_orders_success_response()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -485,6 +485,29 @@ class TestCoinbaseAdvancedTradeAPIClient(unittest.TestCase):
         self.assertTrue(order_edited.success)
 
     @mock.patch("coinbaseadvanced.client.requests.post")
+    def test_edit_order_preview_success(self, mock_post):
+
+        mock_resp = fixture_edit_order_preview_success_response()
+        mock_post.return_value = mock_resp
+
+        client = CoinbaseAdvancedTradeAPIClient(
+            api_key='kjsldfk32234', secret_key='jlsjljsfd89y98y98shdfjksfd')
+
+        # Check output
+        order_edit_preview = client.edit_order_preview(
+            "nlksdbnfgjd8y9mn,m234", .19, 10000)
+
+        self.assertEqual(order_edit_preview.errors, [])
+        self.assertIsNotNone(order_edit_preview.base_size)
+        self.assertIsNotNone(order_edit_preview.average_filled_price)
+        self.assertIsNotNone(order_edit_preview.best_ask)
+        self.assertIsNotNone(order_edit_preview.best_bid)
+        self.assertIsNotNone(order_edit_preview.commission_total)
+        self.assertIsNotNone(order_edit_preview.order_total)
+        self.assertIsNotNone(order_edit_preview.quote_size)
+        self.assertIsNotNone(order_edit_preview.slippage)
+
+    @mock.patch("coinbaseadvanced.client.requests.post")
     def test_cancel_orders_success(self, mock_post):
 
         mock_resp = fixture_cancel_orders_success_response()


### PR DESCRIPTION
This is a follow-up of @jonandtice [PR here](https://github.com/KmiQ/coinbase-advanced-python/pull/54). I'm tweaking a bit the code, adding unit tests and fixtures. I also took the opportunity to add the new `retail_porfolio_id` arg to the order creation functions (context about that [here](https://forums.coinbasecloud.dev/t/how-to-trade-within-portfolios-coinbase-advanced-py/6998)). In addition, I added support for the `edit_order_preview` endpoint.

cc: @jonandtice 